### PR TITLE
added host header for fsock

### DIFF
--- a/ipnlistener.php
+++ b/ipnlistener.php
@@ -146,6 +146,7 @@ class IpnListener {
         } 
 
         $header = "POST /cgi-bin/webscr HTTP/1.0\r\n";
+        $header .= "Host: ".$this->getPaypalHost()."\r\n";
         $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
         $header .= "Content-Length: ".strlen($encoded_data)."\r\n";
         $header .= "Connection: Close\r\n\r\n";


### PR DESCRIPTION
When using fsockopen to communicate with PayPal, was getting the following response back

```
HTTP/1.0 400 Bad Request
Server: BigIP
Connection: close
Content-Length: 19

Invalid Host header
```

Setting the host header fixes this issue
