### PR TITLE
Update to HTTP 1.1

### DIFF
--- a/ipnlistener.php
+++ b/ipnlistener.php
@@ -145,7 +145,7 @@ class IpnListener {
             throw new Exception("fsockopen error: [$errno] $errstr");
         } 
 
-        $header = "POST /cgi-bin/webscr HTTP/1.0\r\n";
+        $header = "POST /cgi-bin/webscr HTTP/1.1\r\n";
         $header .= "Host: ".$this->getPaypalHost()."\r\n";
         $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
         $header .= "Content-Length: ".strlen($encoded_data)."\r\n";


### PR DESCRIPTION
Changed from using the HTTP 1.0 protocol to HTTP 1.1 - PayPal is
dropping HTTP 1.0 support from February 2013.
