### PR TITLE
Update SSL version

### DIFF
--- a/ipnlistener.php
+++ b/ipnlistener.php
@@ -28,7 +28,7 @@ class IpnListener {
      *
      *  @var boolean
      */
-    public $force_ssl_v3 = true;     
+    public $force_ssl_v3 = false;     
    
     /**
      *  If true, cURL will use the CURLOPT_FOLLOWLOCATION to follow any 
@@ -93,10 +93,10 @@ class IpnListener {
         
         $ch = curl_init();
 
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-		curl_setopt($ch, CURLOPT_CAINFO, 
-		            dirname(__FILE__)."/cert/api_cert_chain.crt");
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+	curl_setopt($ch, CURLOPT_CAINFO, 
+	dirname(__FILE__)."/cert/api_cert_chain.crt");
         curl_setopt($ch, CURLOPT_URL, $uri);
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded_data);
@@ -104,9 +104,12 @@ class IpnListener {
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 1);
         
         if ($this->force_ssl_v3) {
-            curl_setopt($ch, CURLOPT_SSLVERSION, 4);
+            // You should know that Paypal does not recommand using this version
+            // https://github.com/paypal/rest-api-sdk-php/commit/8e193664151578a0eeeca1129c9f3203951ac15a
+            curl_setopt($ch, CURLOPT_SSLVERSION, 3);
         }
         
         $this->response = curl_exec($ch);


### PR DESCRIPTION
SSL v3 does not work anymore to check IPN with Paypal.

Set default version to SSLv1. Set default force_ssl_v3 to false.
